### PR TITLE
fix: 将 flutter_miuix 本地依赖改为固定 Git 提交

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -286,10 +286,12 @@ packages:
   flutter_miuix:
     dependency: "direct main"
     description:
-      path: ".vendor/flutter_miuix"
-      relative: true
-    source: path
-    version: "1.0.9"
+      path: "."
+      ref: ef5c1312d7aab00670a2539ff67bc3b88086f795
+      resolved-ref: ef5c1312d7aab00670a2539ff67bc3b88086f795
+      url: "https://github.com/Mutx163/flutter_miuix.git"
+    source: git
+    version: "1.0.10"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -1146,5 +1148,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.0 <4.0.0"
+  dart: ">=3.12.2 <4.0.0"
   flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,10 @@ dependencies:
   fast_gbk: ^1.0.0
   flutter_svg: ^2.3.0
   image: ^4.8.0
-  flutter_miuix: ^1.0.9
+  flutter_miuix:
+    git:
+      url: https://github.com/Mutx163/flutter_miuix.git
+      ref: ef5c1312d7aab00670a2539ff67bc3b88086f795
   liquid_glass_renderer: ^0.2.0-dev.4
   flutter_blackbox: ^0.7.0
   fountain_codes: ^1.0.0
@@ -52,12 +55,6 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
   fake_async: ^1.3.3
-
-# 本地开发：字重跟随系统的改动尚未发布到 pub，先用本地克隆覆盖（.vendor 已 gitignore）。
-# PR 合并/发版后可移除本段，回到 pub 上的 flutter_miuix。
-dependency_overrides:
-  flutter_miuix:
-    path: .vendor/flutter_miuix
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## 背景
CI 无法获取未提交到仓库的 `.vendor/flutter_miuix` 本地路径依赖，导致 `flutter pub get` 失败。

## 变更
- 将 `flutter_miuix` 从 `.vendor/flutter_miuix` path override 改为 Git 依赖
- 固定到 `Mutx163/flutter_miuix` 的提交 `ef5c1312d7aab00670a2539ff67bc3b88086f795`
- 更新 `pubspec.lock`，来源改为 `git`、版本为 `1.0.10`

## 验证
- `flutter pub get`：通过，确认锁文件为 Git 来源
- `flutter analyze`：通过
- 相关测试：`flutter test test/widgets/course_import_screen_test.dart test/services/app_log_service_test.dart` 通过
- `flutter build apk --debug --flavor dev --no-pub`：通过
- 全量 `flutter test`：仍有 6 个既有 `timetable_day_view_test.dart` 失败，未新增失败；失败与本依赖替换无关