### PR TITLE
MUT-12: stabilize widget finders and plugin smoke tests

### DIFF
--- a/docs/reference/hyperos-page-compliance.json
+++ b/docs/reference/hyperos-page-compliance.json
@@ -124,7 +124,7 @@
     },
     {
       "id": "time-scheme-bottom-sheet",
-      "file": "lib/screens/time_scheme_bottom_sheet.dart",
+      "file": "lib/widgets/time_scheme_picker_sheet.dart",
       "label": "时间方案 Sheet",
       "category": "sheet",
       "expectedShell": "HyperosSheet",

--- a/docs/reference/hyperos-ui-kit.md
+++ b/docs/reference/hyperos-ui-kit.md
@@ -213,7 +213,7 @@ Toast 入口：`lib/utils/app_toast.dart` → [app-toast.md](./app-toast.md)。
 | 界面 | 文件 | 状态 |
 |------|------|------|
 | 学期周数选择 | `semester_week_count_picker_sheet.dart` | ✅ `HyperosSheet` + `HyperosChoiceGroup` |
-| 时间方案 bottom sheet | `time_scheme_bottom_sheet.dart` | ✅ |
+| 时间方案 bottom sheet | `time_scheme_picker_sheet.dart` | ✅ |
 
 ### 3.5 表单 / 业务页
 
@@ -286,7 +286,7 @@ P0–P2 核心组件与 **全 app 对话框迁移** 已完成（§2.6）。仍�
 ### 阶段 F — 弹层与次要页 ✅
 
 - [x] `time_scheme_management_screen.dart`
-- [x] `time_scheme_bottom_sheet.dart`
+- [x] `time_scheme_picker_sheet.dart`
 - [x] `timetable_profiles_screen.dart`
 - [x] `course_overview_screen.dart`
 

--- a/lib/providers/timetable_provider.dart
+++ b/lib/providers/timetable_provider.dart
@@ -3258,13 +3258,14 @@ class TimetableProvider with ChangeNotifier {
       ..sort((a, b) => a.startSection.compareTo(b.startSection));
   }
 
-  List<Course> getTodayCourses() {
+  List<Course> getTodayCourses({DateTime? now}) {
     // After the term ends, UI currentDateWeek is clamped to semesterWeekCount.
     // "Today's courses" must use the real calendar week so finished courses do
     // not keep appearing every weekday that matches the last teaching week.
+    final reference = now ?? DateTime.now();
     final targetWeek = _settings.semesterStartDate == null
         ? _currentDateWeek
-        : _calculateCalendarWeekForDate(DateTime.now());
+        : _calculateCalendarWeekForDate(reference);
     return getCoursesForDay(_currentDayOfWeek, week: targetWeek);
   }
 

--- a/lib/screens/miuix_showcase/theming.dart
+++ b/lib/screens/miuix_showcase/theming.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_miuix/miuix.dart';
+import 'package:university_timetable/ui/hyperos/hyperos.dart';
 
 import 'common.dart';
 
@@ -31,7 +32,7 @@ class ThemingShowcase extends StatelessWidget {
                   insideMargin: margin,
                   onClick: () => Navigator.of(
                     context,
-                  ).push(MaterialPageRoute(builder: (_) => e.$3)),
+                  ).push(HyperosPageRoute(builder: (_) => e.$3)),
                 ),
               ],
             ],

--- a/lib/screens/miuix_showcase_screen.dart
+++ b/lib/screens/miuix_showcase_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_miuix/miuix.dart';
+import 'package:university_timetable/ui/hyperos/hyperos.dart';
 
 import 'miuix_showcase/buttons.dart';
 import 'miuix_showcase/common.dart';
@@ -55,7 +56,7 @@ class _MiuixShowcaseScreenState extends State<MiuixShowcaseScreen> {
         child: Navigator(
           key: _nestedNavigatorKey,
           onGenerateInitialRoutes: (navigator, initialRoute) {
-            return [MaterialPageRoute<void>(builder: (_) => const _HomePage())];
+            return [HyperosPageRoute<void>(builder: (_) => const _HomePage())];
           },
         ),
       ),
@@ -1095,7 +1096,7 @@ class _SearchResultItem extends StatelessWidget {
         final navigator = Navigator.of(context);
         onCommitQuery?.call();
         onDismiss?.call();
-        navigator.push(MaterialPageRoute(builder: (_) => entry.page));
+        navigator.push(HyperosPageRoute(builder: (_) => entry.page));
       },
     );
   }
@@ -1141,7 +1142,7 @@ class _EntryTile extends StatelessWidget {
       ),
       onClick: () => Navigator.of(
         context,
-      ).push(MaterialPageRoute(builder: (_) => entry.page)),
+      ).push(HyperosPageRoute(builder: (_) => entry.page)),
     );
   }
 }

--- a/lib/utils/managed_image_storage.dart
+++ b/lib/utils/managed_image_storage.dart
@@ -8,14 +8,19 @@ import 'package:path_provider/path_provider.dart';
 ///
 /// 返回 null 表示用户取消选择或读取失败。相册选择走系统 Photo Picker /
 /// 系统相册界面，无需申请存储权限。
+typedef ManagedImagePicker = Future<XFile?> Function();
+
 Future<String?> pickAndStoreManagedImage({
   required String directoryName,
   required String filePrefix,
   bool cleanupArtifacts = true,
+  ManagedImagePicker? imagePicker,
 }) async {
   final XFile? pickedImage;
   try {
-    pickedImage = await ImagePicker().pickImage(source: ImageSource.gallery);
+    pickedImage =
+        await (imagePicker ??
+            () => ImagePicker().pickImage(source: ImageSource.gallery))();
   } on Exception {
     return null;
   }

--- a/test/providers/timetable_provider_day_view_test.dart
+++ b/test/providers/timetable_provider_day_view_test.dart
@@ -136,18 +136,26 @@ void main() {
         ),
       );
 
-      await provider.syncTemporalContext(now: DateTime(2026, 4, 13, 8, 30));
+      final monday = DateTime(2026, 4, 13, 8, 30);
+      await provider.syncTemporalContext(now: monday);
       expect(provider.currentWeek, 1);
       expect(provider.currentDateWeek, 1);
       expect(provider.currentDayOfWeek, 1);
-      expect(provider.getTodayCourses().map((course) => course.name), ['周一课程']);
+      expect(
+        provider.getTodayCourses(now: monday).map((course) => course.name),
+        ['周一课程'],
+      );
 
       await provider.setCurrentWeek(6);
-      await provider.syncTemporalContext(now: DateTime(2026, 4, 21, 8, 30));
+      final tuesday = DateTime(2026, 4, 21, 8, 30);
+      await provider.syncTemporalContext(now: tuesday);
       expect(provider.currentWeek, 6);
       expect(provider.currentDateWeek, 2);
       expect(provider.currentDayOfWeek, 2);
-      expect(provider.getTodayCourses().map((course) => course.name), ['周二课程']);
+      expect(
+        provider.getTodayCourses(now: tuesday).map((course) => course.name),
+        ['周二课程'],
+      );
     },
   );
 }

--- a/test/services/plugin_boundary_smoke_test.dart
+++ b/test/services/plugin_boundary_smoke_test.dart
@@ -1,0 +1,321 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:math';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+import 'package:university_timetable/screens/qr_transfer_scan_screen.dart';
+import 'package:university_timetable/services/app_migration_service.dart';
+import 'package:university_timetable/services/qr_transfer/qr_transfer_codec.dart';
+import 'package:university_timetable/utils/managed_image_storage.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+// ignore: depend_on_referenced_packages
+import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
+
+import '../helpers_test_app.dart';
+
+class _FakeMobileScannerPlatform extends MobileScannerPlatform {
+  final StreamController<BarcodeCapture?> _barcodes =
+      StreamController<BarcodeCapture?>.broadcast();
+  final StreamController<TorchState> _torch =
+      StreamController<TorchState>.broadcast();
+  final StreamController<double> _zoom = StreamController<double>.broadcast();
+  int startCalls = 0;
+  int stopCalls = 0;
+  int disposeCalls = 0;
+  StartOptions? lastStartOptions;
+
+  @override
+  Stream<BarcodeCapture?> get barcodesStream => _barcodes.stream;
+
+  @override
+  Stream<TorchState> get torchStateStream => _torch.stream;
+
+  @override
+  Stream<double> get zoomScaleStateStream => _zoom.stream;
+
+  @override
+  Widget buildCameraView() => const SizedBox.expand();
+
+  @override
+  Future<MobileScannerViewAttributes> start(StartOptions startOptions) async {
+    startCalls++;
+    lastStartOptions = startOptions;
+    return const MobileScannerViewAttributes(
+      cameraDirection: CameraFacing.back,
+      currentTorchMode: TorchState.off,
+      numberOfCameras: 1,
+      size: Size(640, 480),
+    );
+  }
+
+  @override
+  Future<void> stop() async {
+    stopCalls++;
+  }
+
+  @override
+  Future<void> dispose() async {
+    disposeCalls++;
+    await _barcodes.close();
+    await _torch.close();
+    await _zoom.close();
+  }
+
+  void emit(BarcodeCapture capture) {
+    _barcodes.add(capture);
+  }
+}
+
+class _FakeWebViewController extends PlatformWebViewController {
+  // ignore: use_super_parameters, the platform interface requires a named protected constructor.
+  _FakeWebViewController(PlatformWebViewControllerCreationParams params)
+    : super.implementation(params);
+
+  Uri? loadedUri;
+  JavaScriptMode? javaScriptMode;
+  String? userAgent;
+  bool? zoomEnabled;
+
+  @override
+  Future<void> loadRequest(LoadRequestParams params) async {
+    loadedUri = params.uri;
+  }
+
+  @override
+  Future<void> setJavaScriptMode(JavaScriptMode mode) async {
+    javaScriptMode = mode;
+  }
+
+  @override
+  Future<void> setUserAgent(String? value) async {
+    userAgent = value;
+  }
+
+  @override
+  Future<void> enableZoom(bool enabled) async {
+    zoomEnabled = enabled;
+  }
+}
+
+class _FakeWebViewWidget extends PlatformWebViewWidget {
+  // ignore: use_super_parameters, the platform interface requires a named protected constructor.
+  _FakeWebViewWidget(PlatformWebViewWidgetCreationParams params)
+    : super.implementation(params);
+
+  @override
+  Widget build(BuildContext context) {
+    return const ColoredBox(
+      key: ValueKey<String>('fake-webview'),
+      color: Color(0xFF101820),
+    );
+  }
+}
+
+class _FakeWebViewPlatform extends WebViewPlatform {
+  _FakeWebViewController? controller;
+
+  @override
+  PlatformWebViewController createPlatformWebViewController(
+    PlatformWebViewControllerCreationParams params,
+  ) {
+    return controller = _FakeWebViewController(params);
+  }
+
+  @override
+  PlatformWebViewWidget createPlatformWebViewWidget(
+    PlatformWebViewWidgetCreationParams params,
+  ) {
+    return _FakeWebViewWidget(params);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MobileScannerPlatform previousScannerPlatform;
+
+  setUp(() {
+    previousScannerPlatform = MobileScannerPlatform.instance;
+  });
+
+  tearDown(() {
+    MobileScannerPlatform.instance = previousScannerPlatform;
+    MobileScannerController.resetPlatformSessionOwner();
+  });
+
+  testWidgets('QR scan imports a complete stream and tears down the camera', (
+    tester,
+  ) async {
+    final fakePlatform = _FakeMobileScannerPlatform();
+    MobileScannerPlatform.instance = fakePlatform;
+
+    Uint8List? imported;
+    await tester.pumpWidget(
+      TestApp(
+        home: QrTransferScanScreen(
+          onComplete: (bytes) async {
+            imported = bytes;
+          },
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(fakePlatform.startCalls, 1);
+    expect(
+      fakePlatform.lastStartOptions?.formats,
+      contains(BarcodeFormat.qrCode),
+    );
+
+    final original = Uint8List.fromList(
+      List<int>.generate(800, (index) => (index * 37 + 11) & 0xff),
+    );
+    final encoder = QrTransferEncoder.prepare(original);
+    final frames = List<String>.generate(
+      encoder.info.sourceSymbolCount * 8,
+      encoder.frameTextFor,
+    )..shuffle(Random(7));
+
+    for (final frame in frames) {
+      fakePlatform.emit(BarcodeCapture(barcodes: [Barcode(rawValue: frame)]));
+      await tester.pump();
+      if (imported != null) {
+        break;
+      }
+    }
+    for (var i = 0; i < 5 && imported == null; i++) {
+      await tester.pump(const Duration(milliseconds: 80));
+    }
+
+    expect(imported, orderedEquals(original));
+    expect(fakePlatform.stopCalls, greaterThanOrEqualTo(1));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+    expect(fakePlatform.disposeCalls, greaterThanOrEqualTo(1));
+  });
+
+  test(
+    'photo picker cancellation and byte reads use the platform seam',
+    () async {
+      const pathProviderChannel = MethodChannel(
+        'plugins.flutter.io/path_provider',
+      );
+      final documentsDirectory = await Directory.systemTemp.createTemp(
+        'mikcb-plugin-smoke-',
+      );
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+            pathProviderChannel,
+            (call) async => documentsDirectory.path,
+          );
+      addTearDown(() async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(pathProviderChannel, null);
+        if (await documentsDirectory.exists()) {
+          await documentsDirectory.delete(recursive: true);
+        }
+      });
+
+      var pickerCalls = 0;
+      XFile? nextImage;
+      Future<XFile?> pickImage() async {
+        pickerCalls++;
+        return nextImage;
+      }
+
+      final cancelled = await pickAndStoreManagedImage(
+        directoryName: 'plugin-smoke-cancel',
+        filePrefix: 'wallpaper',
+        imagePicker: pickImage,
+      );
+      expect(cancelled, isNull);
+      expect(pickerCalls, 1);
+
+      final bytes = Uint8List.fromList([0, 1, 2, 3, 4]);
+      final sourceFile = File(
+        '${documentsDirectory.path}${Platform.pathSeparator}picked.JPG',
+      );
+      await sourceFile.writeAsBytes(bytes);
+      nextImage = XFile(sourceFile.path);
+      final directoryName =
+          'plugin-smoke-${DateTime.now().microsecondsSinceEpoch}';
+      final path = await pickAndStoreManagedImage(
+        directoryName: directoryName,
+        filePrefix: 'wallpaper',
+        imagePicker: pickImage,
+      );
+
+      expect(path, isNotNull);
+      final storedFile = File(path!);
+      expect(storedFile.path.toLowerCase(), endsWith('.jpg'));
+      expect(await storedFile.readAsBytes(), bytes);
+      await storedFile.parent.delete(recursive: true);
+    },
+  );
+
+  testWidgets('WebView controller loads through a replaceable platform', (
+    tester,
+  ) async {
+    final fakePlatform = _FakeWebViewPlatform();
+    WebViewPlatform.instance = fakePlatform;
+
+    final controller = WebViewController();
+    await controller.setJavaScriptMode(JavaScriptMode.unrestricted);
+    await controller.enableZoom(true);
+    await controller.setUserAgent('test-agent');
+    await controller.loadRequest(Uri.parse('https://example.test/login'));
+
+    expect(
+      fakePlatform.controller?.javaScriptMode,
+      JavaScriptMode.unrestricted,
+    );
+    expect(fakePlatform.controller?.zoomEnabled, isTrue);
+    expect(fakePlatform.controller?.userAgent, 'test-agent');
+    expect(
+      fakePlatform.controller?.loadedUri,
+      Uri.parse('https://example.test/login'),
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(home: WebViewWidget(controller: controller)),
+    );
+    expect(find.byKey(const ValueKey<String>('fake-webview')), findsOneWidget);
+  });
+
+  test('MethodChannel migration flow forwards arguments and results', () async {
+    const channel = MethodChannel('com.mutx163.qingyu/migration');
+    final calls = <MethodCall>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (call) async {
+          calls.add(call);
+          return switch (call.method) {
+            'findInstalledPackage' => 'com.example.legacy',
+            'openPackage' => true,
+            _ => null,
+          };
+        });
+    addTearDown(
+      () => TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null),
+    );
+
+    final service = AppMigrationService();
+    expect(
+      await service.findInstalledLegacyPackage(
+        candidates: const ['com.example.legacy'],
+      ),
+      'com.example.legacy',
+    );
+    expect(await service.openPackage('com.example.legacy'), isTrue);
+    expect(calls.map((call) => call.method), [
+      'findInstalledPackage',
+      'openPackage',
+    ]);
+    expect(calls.first.arguments, ['com.example.legacy']);
+    expect(calls.last.arguments, 'com.example.legacy');
+  });
+}

--- a/test/ui/hyperos/hyperos_subpage_navigation_test.dart
+++ b/test/ui/hyperos/hyperos_subpage_navigation_test.dart
@@ -499,12 +499,10 @@ void main() {
     await tester.pump();
 
     Finder headerScope() {
-      return find.ancestor(
-        of: find.text('Settings'),
-        matching: find.byWidgetPredicate(
-          (widget) => widget is HyperosBlurredHeaderScope,
-        ),
-      );
+      // Collapsible headers render the large and small title together, so
+      // text ancestry returns the same scope twice. The page owns one scope;
+      // target it directly instead of depending on title multiplicity.
+      return find.byType(HyperosBlurredHeaderScope);
     }
 
     expect(

--- a/test/widgets/timetable_settings_screen_test.dart
+++ b/test/widgets/timetable_settings_screen_test.dart
@@ -17,6 +17,10 @@ Future<void> _pumpScreen(WidgetTester tester) async {
   await tester.pump(const Duration(milliseconds: 500));
 }
 
+Finder _scrollableUnder(Finder host) {
+  return find.descendant(of: host, matching: find.byType(Scrollable)).first;
+}
+
 void _seedInitializedPrefs() {
   final now = DateTime(2026, 4, 12);
   final settings = TimetableSettings.defaults();
@@ -97,26 +101,29 @@ void main() {
     );
     await _pumpScreen(tester);
 
+    final homeList = find.byType(HyperosListView).first;
     await tester.scrollUntilVisible(
       find.text('超级岛与通知'),
       200,
-      scrollable: find.byType(Scrollable).first,
+      scrollable: _scrollableUnder(homeList),
     );
     await tester.tap(find.text('超级岛与通知'));
     await tester.pumpAndSettle();
 
+    final liveList = find.byType(HyperosListView).last;
     await tester.scrollUntilVisible(
-      find.text('测试与诊断'),
+      find.text('自检'),
       200,
-      scrollable: find.byType(Scrollable).last,
+      scrollable: _scrollableUnder(liveList),
     );
-    await tester.tap(find.text('测试与诊断'));
+    await tester.tap(find.text('自检'));
     await tester.pumpAndSettle();
 
+    final diagnosticsList = find.byType(HyperosListView).last;
     await tester.scrollUntilVisible(
       find.textContaining('自动刷新'),
       200,
-      scrollable: find.byType(Scrollable).last,
+      scrollable: _scrollableUnder(diagnosticsList),
     );
     expect(find.textContaining('每 1 秒自动拉取一次诊断状态'), findsOneWidget);
     expect(find.textContaining('上次刷新：'), findsOneWidget);
@@ -138,10 +145,11 @@ void main() {
     );
     await _pumpScreen(tester);
 
+    final homeList = find.byType(HyperosListView).first;
     await tester.scrollUntilVisible(
       find.text('超级岛与通知'),
       200,
-      scrollable: find.byType(Scrollable).first,
+      scrollable: _scrollableUnder(homeList),
     );
     await tester.tap(find.text('超级岛与通知'));
     await tester.pumpAndSettle();
@@ -157,7 +165,7 @@ void main() {
     await tester.scrollUntilVisible(
       find.text('时间阈值'),
       200,
-      scrollable: find.byType(Scrollable).last,
+      scrollable: _scrollableUnder(find.byType(HyperosListView).last),
     );
     await tester.pumpAndSettle();
     await tester.tap(find.text('20 分钟').first);
@@ -183,10 +191,8 @@ void main() {
     );
     await _pumpScreen(tester);
 
-    final homeScrollable = find.descendant(
-      of: find.byType(HyperosListView).first,
-      matching: find.byType(Scrollable),
-    );
+    final homeList = find.byType(HyperosListView).first;
+    final homeScrollable = _scrollableUnder(homeList);
     await tester.scrollUntilVisible(
       find.text('超级岛与通知'),
       200,
@@ -200,8 +206,8 @@ void main() {
         .pixels;
     expect(pixelsBefore, greaterThan(100));
 
-    final liveTile = find.widgetWithText(HyperosListTile, '超级岛与通知');
-    final onTap = tester.widget<HyperosListTile>(liveTile).onTap;
+    final liveTile = find.widgetWithText(HyperosPressableRow, '超级岛与通知');
+    final onTap = tester.widget<HyperosPressableRow>(liveTile).onTap;
     expect(onTap, isNotNull);
     onTap!.call();
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- Stabilize settings and HyperOS Finders against current widget structure and localized labels.
- Add deterministic temporal-clock injection for today-course tests.
- Add replaceable-plugin smoke coverage for QR/camera lifecycle and import callback, photo picker cancel/read, WebView load, and MethodChannel migration.

## Verification
- flutter analyze
- flutter test
- flutter test test/services/plugin_boundary_smoke_test.dart

Full suite: 1,034 passed, 3 skipped.